### PR TITLE
Prefix feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,6 +12,8 @@ import (
 )
 
 func main() {
+	checkPtr := flag.Bool("check-name", false, "enable check name prefix")
+	entityPtr := flag.Bool("entity-name", false, "enable entity name prefix")
 	eventJSON, err := ioutil.ReadAll(os.Stdin)
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -12,8 +12,10 @@ import (
 )
 
 func main() {
-	checkPtr := flag.Bool("check-name", false, "enable check name prefix")
-	entityPtr := flag.Bool("entity-name", false, "enable entity name prefix")
+	checkPtr := flag.Bool("check-prefix", false, "enable check name prefix")
+	entityPtr := flag.Bool("entity-prefix", false, "enable entity name prefix")
+	flag.Parse()
+
 	eventJSON, err := ioutil.ReadAll(os.Stdin)
 
 	if err != nil {
@@ -23,24 +25,37 @@ func main() {
 
 	event := &types.Event{}
 	err = json.Unmarshal(eventJSON, event)
-
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to unmarshal STDIN data: %s", err)
 		os.Exit(1)
 	}
-
+	if event.Metrics == nil {
+		fmt.Fprintf(os.Stderr, "No Metrics in event\n")
+		os.Exit(1)
+	}
 	for _, point := range event.Metrics.Points {
 		tags := ""
+		pointName := ""
 		for _, tag := range point.Tags {
 			tags = tags + fmt.Sprintf("%s=\"%v\"", tag.Name, tag.Value)
 		}
 
 		timestamp := point.Timestamp
-
+		if *entityPtr {
+			if event.Entity != nil {
+				pointName += event.Entity.Name + "."
+			}
+		}
+		if *checkPtr {
+			if event.Check != nil {
+				pointName += event.Check.Name + "."
+			}
+		}
+		pointName += point.Name
 		if timestamp < 1000000000000 {
 			timestamp = time.Unix(timestamp, 0).UnixNano() / int64(time.Millisecond)
 		}
 
-		fmt.Printf("%s{%s} %v %v\n", point.Name, tags, point.Value, timestamp)
+		fmt.Printf("%s{%s} %v %v\n", pointName, tags, point.Value, timestamp)
 	}
 }


### PR DESCRIPTION
Adding cmdline options to enable entity and/or check name prefix for metrics.

This is really useful for proxy request metrics or using a metrics command that doesn't support a prefix scheme itself...such as nagios perfdata metrics.

Closes #1 